### PR TITLE
Sync rulers with canvas size and zoom

### DIFF
--- a/gui/canvas_view.py
+++ b/gui/canvas_view.py
@@ -195,10 +195,18 @@ class CanvasView(QGraphicsView):
     
     def _update_rulers_scale(self):
         """Оновити масштаб лінейок"""
-        if self.h_ruler and self.v_ruler:
-            logger.debug(f"[RULER-SCALE] Updated to: {self.current_scale:.2f}")
+        updated = False
+
+        if self.h_ruler:
             self.h_ruler.update_scale(self.current_scale)
+            updated = True
+
+        if self.v_ruler:
             self.v_ruler.update_scale(self.current_scale)
+            updated = True
+
+        if updated:
+            logger.debug(f"[RULER-SCALE] Updated to: {self.current_scale:.2f}")
     
     def zoom_in(self):
         """Zoom in відносно центру viewport"""
@@ -252,6 +260,15 @@ class CanvasView(QGraphicsView):
         self.height_mm = height_mm
         self.width_px = round(self._mm_to_px(width_mm))
         self.height_px = round(self._mm_to_px(height_mm))
+
+        # Оновити лінейки, якщо вони прикріплені до canvas
+        if self.h_ruler:
+            self.h_ruler.set_length(width_mm)
+        if self.v_ruler:
+            self.v_ruler.set_length(height_mm)
+
+        # Переконатися, що масштаб лінейок синхронізований з canvas
+        self._update_rulers_scale()
         
         logger.debug(f"[LABEL-SIZE] Width: {width_mm}mm = {self.width_px}px")
         logger.debug(f"[LABEL-SIZE] Height: {height_mm}mm = {self.height_px}px")

--- a/gui/mixins/label_config_mixin.py
+++ b/gui/mixins/label_config_mixin.py
@@ -70,10 +70,6 @@ class LabelConfigMixin:
         # Застосувати до canvas
         self.canvas.set_label_size(width_mm, height_mm)
         
-        # Оновити лінейки
-        self.h_ruler.set_length(width_mm)
-        self.v_ruler.set_length(height_mm)
-        
         logger.info(f"[SIZE-APPLY] Label size updated: {width_mm}x{height_mm}mm")
     
     def _create_units_controls(self):

--- a/gui/mixins/template_mixin.py
+++ b/gui/mixins/template_mixin.py
@@ -168,9 +168,7 @@ class TemplateMixin:
             if width_mm != self.canvas.width_mm or height_mm != self.canvas.height_mm:
                 logger.info(f"[LOAD-TEMPLATE] Applying new label size: {width_mm}x{height_mm}mm")
                 self.canvas.set_label_size(width_mm, height_mm)
-                self.h_ruler.set_length(width_mm)
-                self.v_ruler.set_length(height_mm)
-                
+
                 self.width_spinbox.blockSignals(True)
                 self.height_spinbox.blockSignals(True)
                 self.width_spinbox.setValue(width_mm)


### PR DESCRIPTION
## Summary
- update the canvas to push new dimensions to attached rulers and refresh their zoom scale
- allow ruler scale updates when only one ruler is attached
- remove redundant ruler length updates from label sizing and template mixins

## Testing
- pytest tests/test_label_size_smart.py *(fails: ImportError: libGL.so.1 missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23f53d524832088273bd8c31e7860