### PR TITLE
Fix grid visibility when cached handles are deleted

### DIFF
--- a/gui/canvas_view.py
+++ b/gui/canvas_view.py
@@ -120,8 +120,34 @@ class CanvasView(QGraphicsView):
         if not self.grid_items:
             self._draw_grid()
 
+        needs_rebuild = False
+
         for item in self.grid_items:
-            item.setVisible(self.grid_visible)
+            if item is None:
+                needs_rebuild = True
+                break
+
+            try:
+                if item.scene() is None:
+                    needs_rebuild = True
+                    break
+
+                item.setVisible(self.grid_visible)
+            except RuntimeError:
+                needs_rebuild = True
+                break
+
+        if needs_rebuild:
+            self.grid_items = []
+            self._draw_grid()
+
+            for item in self.grid_items:
+                try:
+                    item.setVisible(self.grid_visible)
+                except RuntimeError:
+                    # Если элемент оказался удален сразу после создания,
+                    # просто пропустим его, следующая итерация відновить сітку.
+                    pass
     
     def _on_selection_changed(self):
         """Обробка зміни виділення (для multi-select)"""


### PR DESCRIPTION
## Summary
- guard the grid visibility toggle against deleted scene items
- rebuild the cached grid lines and border before applying visibility when needed

## Testing
- not run (GUI-dependent tests)

------
https://chatgpt.com/codex/tasks/task_e_68e246c82e248320aa5d27a895655d41