### PR TITLE
Fix ruler highlights to track dragged items

### DIFF
--- a/core/elements/text_element.py
+++ b/core/elements/text_element.py
@@ -4,6 +4,8 @@
 from PySide6.QtWidgets import QGraphicsTextItem, QGraphicsItem
 from PySide6.QtCore import Qt, Signal, QPointF
 from PySide6.QtGui import QFont
+
+from utils.logger import logger
 from .base import BaseElement, ElementConfig
 
 class TextElement(BaseElement):
@@ -44,7 +46,6 @@ class TextElement(BaseElement):
     
     def to_zpl(self, dpi):
         """Генерация ZPL кода"""
-        from utils.logger import logger
         
         # Конвертация мм → dots
         x_dots = int(self.config.x * dpi / 25.4)
@@ -132,62 +133,81 @@ class GraphicsTextItem(QGraphicsTextItem):
         # SNAP TO GRID - при движении
         if change == QGraphicsItem.ItemPositionChange:
             new_pos = value
-            
+
             # Конвертувати у мм
             x_mm = self._px_to_mm(new_pos.x())
             y_mm = self._px_to_mm(new_pos.y())
-            
+
+            logger.debug(
+                f"[ITEM-DRAG] Position changing: ({new_pos.x():.2f}, {new_pos.y():.2f})px -> "
+                f"({x_mm:.2f}, {y_mm:.2f})mm"
+            )
+
             # EMIT cursor position для rulers при drag
             if self.canvas:
-                from utils.logger import logger
                 logger.debug(f"[ITEM-DRAG] Emitting cursor: ({x_mm:.2f}, {y_mm:.2f})mm")
                 self.canvas.cursor_position_changed.emit(x_mm, y_mm)
-            
+
             if self.snap_enabled:
                 # Snap до сітки (окремо для X та Y)
                 snapped_x = self._snap_to_grid(x_mm, 'x')
                 snapped_y = self._snap_to_grid(y_mm, 'y')
-                
-                # DEBUG
-                from utils.logger import logger
+
                 if snapped_x != x_mm or snapped_y != y_mm:
-                    logger.debug(f"[SNAP] {x_mm:.2f}mm, {y_mm:.2f}mm -> {snapped_x:.1f}mm, {snapped_y:.1f}mm")
-                
+                    logger.debug(
+                        f"[SNAP] {x_mm:.2f}mm, {y_mm:.2f}mm -> {snapped_x:.1f}mm, {snapped_y:.1f}mm"
+                    )
+
                 # Конвертувати назад у пікселі
                 snapped_pos = QPointF(
                     self._mm_to_px(snapped_x),
                     self._mm_to_px(snapped_y)
                 )
-                
+
                 return snapped_pos
-            
+
             return new_pos
-        
+
         # ОБНОВЛЕНИЕ ЭЛЕМЕНТА - после движения
         if change == QGraphicsTextItem.ItemPositionHasChanged:
             # Обновить элемент с учетом snap
             x_mm = self._px_to_mm(self.pos().x())
             y_mm = self._px_to_mm(self.pos().y())
-            
+
+            logger.debug(
+                f"[ITEM-DRAG] Position changed (raw): ({self.pos().x():.2f}, {self.pos().y():.2f})px -> "
+                f"({x_mm:.2f}, {y_mm:.2f})mm"
+            )
+
             # Применить snap если включен
             if self.snap_enabled:
                 x_mm = self._snap_to_grid(x_mm)
                 y_mm = self._snap_to_grid(y_mm)
-            
+
             self.element.config.x = x_mm
             self.element.config.y = y_mm
-            
+
             # Сигнал об изменении
             self.position_changed.emit(
-                self.element.config.x, 
+                self.element.config.x,
                 self.element.config.y
             )
-        
+
+            if (
+                self.canvas
+                and getattr(self.canvas, 'bounds_update_callback', None)
+                and self.isSelected()
+            ):
+                logger.debug(
+                    f"[ITEM-DRAG] Position changed: bounds update needed "
+                    f"({self.element.config.x:.2f}, {self.element.config.y:.2f})mm"
+                )
+                self.canvas.bounds_update_callback(self)
+
         return super().itemChange(change, value)
-    
+
     def _snap_to_grid(self, value_mm, axis='x'):
         """Прив'язка до сітки з GridConfig (size, offset)"""
-        from utils.logger import logger
         from config import SnapMode
         
         # Fallback для старих елементів без canvas
@@ -242,7 +262,6 @@ class GraphicsTextItem(QGraphicsTextItem):
     
     def update_display(self):
         """Обновить визуальное отображение с учетом стилей"""
-        from utils.logger import logger
         
         font = self.font()
         

--- a/gui/canvas_view.py
+++ b/gui/canvas_view.py
@@ -62,6 +62,8 @@ class CanvasView(QGraphicsView):
         # Посилання на лінейки (буде встановлено з MainWindow)
         self.h_ruler = None
         self.v_ruler = None
+        # Callback для оновлення bounds highlight під час drag
+        self.bounds_update_callback = None
         
         # Увімкнути mouse tracking
         self.setMouseTracking(True)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -63,6 +63,7 @@ class MainWindow(QMainWindow,
         # Canvas
         self.canvas = CanvasView(width_mm=28, height_mm=28, dpi=203)
         logger.info("Canvas created (28x28mm, DPI 203)")
+        self.canvas.bounds_update_callback = self._highlight_element_bounds
         
         # Sidebar
         self.sidebar = Sidebar()

--- a/gui/mixins/selection_mixin.py
+++ b/gui/mixins/selection_mixin.py
@@ -58,8 +58,8 @@ class SelectionMixin:
             width_mm = width_px * 25.4 / dpi
             height_mm = height_px * 25.4 / dpi
             
-            logger.debug(f"[BOUNDS] Element at: x={x:.2f}mm, y={y:.2f}mm")
-            logger.debug(f"[BOUNDS] Size: width={width_mm:.2f}mm, height={height_mm:.2f}mm")
+            logger.debug(f"[BOUNDS-UPDATE] Position: x={x:.2f}mm, y={y:.2f}mm")
+            logger.debug(f"[BOUNDS-UPDATE] Size: width={width_mm:.2f}mm, height={height_mm:.2f}mm")
             
             self.h_ruler.highlight_bounds(x, width_mm)
             self.v_ruler.highlight_bounds(y, height_mm)

--- a/gui/rulers.py
+++ b/gui/rulers.py
@@ -232,7 +232,11 @@ class RulerWidget(QWidget):
     def highlight_bounds(self, start_mm, width_mm):
         """Підсвітити межі елемента"""
         orientation_name = "H" if self.orientation == Qt.Horizontal else "V"
-        logger.debug(f"[BOUNDS-{orientation_name}] Highlight: start={start_mm:.2f}mm, width={width_mm:.2f}mm")
+        end_mm = start_mm + width_mm
+        logger.debug(
+            f"[RULER-{orientation_name}] Bounds updated: start={start_mm:.2f}mm, "
+            f"end={end_mm:.2f}mm, width={width_mm:.2f}mm"
+        )
         self.highlighted_bounds = (start_mm, width_mm)
         self.update()
     

--- a/tests/run_ruler_drag_bounds_test.py
+++ b/tests/run_ruler_drag_bounds_test.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Runner для smart-теста ruler bounds drag"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+TEST_SCRIPT = ROOT_DIR / 'tests' / 'test_ruler_drag_bounds_smart.py'
+
+env = os.environ.copy()
+env.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+result = subprocess.run(
+    [sys.executable, str(TEST_SCRIPT)],
+    cwd=str(ROOT_DIR),
+    capture_output=True,
+    text=True,
+    env=env,
+)
+
+print(result.stdout)
+if result.stderr:
+    print('STDERR:')
+    print(result.stderr)
+
+print(f"\nEXIT CODE: {result.returncode}")

--- a/tests/test_ruler_drag_bounds_smart.py
+++ b/tests/test_ruler_drag_bounds_smart.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""Умный тест: bounds highlight следует за элементом при drag"""
+
+import os
+import sys
+import re
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QPointF
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from gui.main_window import MainWindow  # noqa: E402
+from utils.logger import logger  # noqa: E402
+
+
+class BoundsDragAnalyzer:
+    """Анализатор логов для bounds during drag"""
+
+    @staticmethod
+    def parse_bounds_logs(log_content: str):
+        """Извлечь логи обновления bounds"""
+        pattern = r"\[RULER-(H|V)\] Bounds updated: start=([\d.\-]+)mm, end=([\d.\-]+)mm, width=([\d.\-]+)mm"
+        matches = re.findall(pattern, log_content)
+        return {
+            'h_bounds': [(float(m[1]), float(m[2])) for m in matches if m[0] == 'H'],
+            'v_bounds': [(float(m[1]), float(m[2])) for m in matches if m[0] == 'V']
+        }
+
+    @staticmethod
+    def parse_drag_logs(log_content: str):
+        """Извлечь логи drag событий"""
+        pattern = r"\[ITEM-DRAG\] Position changed: bounds update needed"
+        return len(re.findall(pattern, log_content))
+
+    @staticmethod
+    def detect_issues(bounds_logs, drag_count, expected_position):
+        """Детектировать проблемы"""
+        issues = []
+
+        # 1. Bounds НЕ обновлялись во время drag
+        if drag_count > 0 and len(bounds_logs['h_bounds']) == 0:
+            issues.append({
+                'type': 'NO_BOUNDS_UPDATE',
+                'desc': f'Drag happened {drag_count} times but bounds never updated'
+            })
+
+        # 2. Количество обновлений bounds != количество drag событий (по горизонтали)
+        if bounds_logs['h_bounds'] and len(bounds_logs['h_bounds']) != drag_count:
+            issues.append({
+                'type': 'BOUNDS_UPDATE_COUNT_MISMATCH',
+                'desc': f'Drag: {drag_count}, Bounds updates: {len(bounds_logs["h_bounds"])}'
+            })
+
+        # 3. Финальная позиция bounds != ожидаемая
+        if bounds_logs['h_bounds']:
+            final_h_bounds = bounds_logs['h_bounds'][-1]
+            expected_x = expected_position[0]
+            if abs(final_h_bounds[0] - expected_x) > 0.5:
+                issues.append({
+                    'type': 'BOUNDS_POSITION_INCORRECT',
+                    'desc': f'Expected x={expected_x:.2f}mm, got {final_h_bounds[0]:.2f}mm'
+                })
+
+        if bounds_logs['v_bounds'] and len(bounds_logs['v_bounds']) != drag_count:
+            issues.append({
+                'type': 'VERTICAL_BOUNDS_UPDATE_COUNT_MISMATCH',
+                'desc': f'Drag: {drag_count}, V bounds updates: {len(bounds_logs["v_bounds"])}'
+            })
+
+        return issues
+
+
+def test_ruler_bounds_during_drag():
+    """Bounds highlight следует за элементом при drag"""
+
+    log_file = ROOT_DIR / 'logs' / 'zpl_designer.log'
+    log_file.parent.mkdir(exist_ok=True)
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.processEvents()
+
+    # Добавить text element и выбрать его
+    window._add_text()
+    app.processEvents()
+
+    assert window.graphics_items, "Text graphics item not created"
+    text_item = window.graphics_items[0]
+    text_item.setSelected(True)
+    app.processEvents()
+
+    file_size_before = log_file.stat().st_size if log_file.exists() else 0
+
+    # Симуляция drag через последовательные setPos (snap применяется внутри)
+    new_positions = [
+        QPointF(100, 100),
+        QPointF(150, 120),
+        QPointF(200, 140),
+    ]
+
+    for new_pos in new_positions:
+        text_item.setPos(new_pos)
+        app.processEvents()
+
+    # Убедиться, что логи сброшены в файл
+    for handler in logger.handlers:
+        if hasattr(handler, 'flush'):
+            handler.flush()
+
+    with log_file.open('r', encoding='utf-8') as f:
+        f.seek(file_size_before)
+        new_logs = f.read()
+
+    analyzer = BoundsDragAnalyzer()
+    bounds_logs = analyzer.parse_bounds_logs(new_logs)
+    drag_count = analyzer.parse_drag_logs(new_logs)
+
+    final_expected_x = text_item.element.config.x
+
+    issues = analyzer.detect_issues(bounds_logs, drag_count, (final_expected_x, 0))
+
+    print('=' * 60)
+    print('[RULER BOUNDS DRAG] LOG ANALYSIS')
+    print('=' * 60)
+    print(f'Drag events: {drag_count}')
+    print(f'H bounds updates: {len(bounds_logs["h_bounds"])}')
+    print(f'V bounds updates: {len(bounds_logs["v_bounds"])}')
+
+    if bounds_logs['h_bounds']:
+        print('\nH bounds positions:')
+        for i, (start, end) in enumerate(bounds_logs['h_bounds'], 1):
+            print(f'  {i}. start={start:.2f}mm, end={end:.2f}mm')
+
+    if bounds_logs['v_bounds']:
+        print('\nV bounds positions:')
+        for i, (start, end) in enumerate(bounds_logs['v_bounds'], 1):
+            print(f'  {i}. start={start:.2f}mm, end={end:.2f}mm')
+
+    window.close()
+    app.processEvents()
+
+    assert not issues, f"Detected issues: {issues}\nLogs:\n{new_logs}"
+
+
+if __name__ == '__main__':
+    sys.exit(0 if test_ruler_bounds_during_drag() is None else 1)


### PR DESCRIPTION
## Summary
- hook a canvas-level callback so graphics items refresh ruler highlights while they move
- add detailed drag debug logging across graphics items and ruler widgets to aid diagnostics
- introduce a log-analyzing smart test and runner that validates ruler bounds tracking during drags

## Testing
- `QT_QPA_PLATFORM=offscreen python tests/test_ruler_drag_bounds_smart.py` *(fails: missing libGL on runner)*

------
https://chatgpt.com/codex/tasks/task_e_68e2820733348320b73537dc7943a301