### PR TITLE
Persist grid and toolbar settings across sessions

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,8 +15,8 @@ class SnapMode(Enum):
 @dataclass
 class GridConfig:
     """Конфігурація сітки (аналогічно ZebraDesigner 3)"""
-    size_x_mm: float = 2.0     # Grid Size X (крок по горизонталі)
-    size_y_mm: float = 2.0     # Grid Size Y (крок по вертикалі)
+    size_x_mm: float = 1.0     # Grid Size X (крок по горизонталі)
+    size_y_mm: float = 1.0     # Grid Size Y (крок по вертикалі)
     offset_x_mm: float = 0.0   # Grid Offset X (зсув початку сітки)
     offset_y_mm: float = 0.0   # Grid Offset Y
     visible: bool = True       # Display gridline guides

--- a/core/elements/barcode_element.py
+++ b/core/elements/barcode_element.py
@@ -86,7 +86,7 @@ class GraphicsBarcodeItem(QGraphicsRectItem):
         
         # Snap to grid - КРИТИЧНО: створити ПЕРЕД setPos()!
         self.snap_enabled = True
-        self.grid_step_mm = 2.0
+        self.grid_step_mm = 1.0
         self.snap_threshold_mm = 1.0  # grid_step / 2 для правильного snap
         
         # Установить позицию (викликає itemChange)
@@ -178,8 +178,8 @@ class GraphicsBarcodeItem(QGraphicsRectItem):
         
         # Fallback для старих елементів без canvas
         if not self.canvas:
-            logger.debug(f"[SNAP-FALLBACK] Using default: size=2.0mm, offset=0.0mm")
-            size = 2.0
+            logger.debug(f"[SNAP-FALLBACK] Using default: size=1.0mm, offset=0.0mm")
+            size = 1.0
             offset = 0.0
             threshold = 1.0
         else:

--- a/core/elements/image_element.py
+++ b/core/elements/image_element.py
@@ -206,7 +206,7 @@ class GraphicsImageItem(QGraphicsPixmapItem):
         
         # Snap to grid - КРИТИЧНО: створити ПЕРЕД setPos()!
         self.snap_enabled = True
-        self.grid_step_mm = 2.0
+        self.grid_step_mm = 1.0
         self.snap_threshold_mm = 1.0
         
         # Завантажити зображення

--- a/core/elements/shape_element.py
+++ b/core/elements/shape_element.py
@@ -274,7 +274,7 @@ class GraphicsRectangleItem(QGraphicsRectItem):
         
         # КРИТИЧНО: створити ПЕРЕД setPos()!
         self.snap_enabled = True
-        self.grid_step_mm = 2.0
+        self.grid_step_mm = 1.0
         self.snap_threshold_mm = 1.0
         
         # Встановити розмір
@@ -418,7 +418,7 @@ class GraphicsCircleItem(QGraphicsEllipseItem):
         
         # КРИТИЧНО: створити ПЕРЕД setPos()!
         self.snap_enabled = True
-        self.grid_step_mm = 2.0
+        self.grid_step_mm = 1.0
         self.snap_threshold_mm = 1.0
         
         # Встановити розмір (еліпс)
@@ -558,7 +558,7 @@ class GraphicsLineItem(QGraphicsLineItem):
         
         # КРИТИЧНО: створити ПЕРЕД setPos()!
         self.snap_enabled = True
-        self.grid_step_mm = 2.0
+        self.grid_step_mm = 1.0
         self.snap_threshold_mm = 1.0
         
         # Встановити лінію

--- a/core/elements/text_element.py
+++ b/core/elements/text_element.py
@@ -114,7 +114,7 @@ class GraphicsTextItem(QGraphicsTextItem):
         
         # Snap to grid - КРИТИЧНО: створити ПЕРЕД setPos()!
         self.snap_enabled = True
-        self.grid_step_mm = 2.0
+        self.grid_step_mm = 1.0
         self.snap_threshold_mm = 1.0  # grid_step / 2 для полного snap
         
         # Установить позицию (викликає itemChange)
@@ -212,8 +212,8 @@ class GraphicsTextItem(QGraphicsTextItem):
         
         # Fallback для старих елементів без canvas
         if not self.canvas:
-            logger.debug(f"[SNAP-FALLBACK] Using default: size=2.0mm, offset=0.0mm")
-            size = 2.0
+            logger.debug(f"[SNAP-FALLBACK] Using default: size=1.0mm, offset=0.0mm")
+            size = 1.0
             offset = 0.0
             threshold = 1.0
         else:

--- a/core/template_manager.py
+++ b/core/template_manager.py
@@ -56,8 +56,8 @@ class TemplateManager:
                 "dpi": label_config.get('dpi', 203),
                 "display_unit": display_unit.value,  # ← зберегти як string
                 "grid": label_config.get('grid', {
-                    'size_x_mm': 2.0,
-                    'size_y_mm': 2.0,
+                    'size_x_mm': 1.0,
+                    'size_y_mm': 1.0,
                     'offset_x_mm': 0.0,
                     'offset_y_mm': 0.0,
                     'visible': True,

--- a/gui/mixins/shortcuts_mixin.py
+++ b/gui/mixins/shortcuts_mixin.py
@@ -82,6 +82,8 @@ class ShortcutsMixin:
         self.guides_enabled = (state == 2)
         self.smart_guides.set_enabled(self.guides_enabled)
         logger.debug(f"[GUIDES-TOGGLE] Enabled: {self.guides_enabled}")
+        if hasattr(self, "_persist_toolbar_settings"):
+            self._persist_toolbar_settings()
     
     def _create_snap_toggle(self):
         """Створити toggle для відображення сітки, snap і smart guides"""
@@ -123,12 +125,8 @@ class ShortcutsMixin:
         else:
             logger.warning("Canvas does not support set_grid_visible")
 
-        # Persist state if відповідні налаштування існують
-        if hasattr(self, "settings"):
-            if isinstance(self.settings, dict):
-                self.settings["show_grid"] = self.grid_visible
-            elif hasattr(self.settings, "setValue"):
-                self.settings.setValue("show_grid", self.grid_visible)
+        if hasattr(self, "_persist_toolbar_settings"):
+            self._persist_toolbar_settings()
     
     def _toggle_snap(self, state):
         """Увімкнути/вимкнути snap"""
@@ -139,8 +137,10 @@ class ShortcutsMixin:
         for item in self.graphics_items:
             if hasattr(item, 'snap_enabled'):
                 item.snap_enabled = self.snap_enabled
-        
+
         logger.info(f"Snap to Grid: {'ON' if self.snap_enabled else 'OFF'} (items: {len(self.graphics_items)})")
+        if hasattr(self, "_persist_toolbar_settings"):
+            self._persist_toolbar_settings()
     
     def _toggle_bold(self):
         """Включить/выключить Bold для selected element"""

--- a/gui/mixins/template_mixin.py
+++ b/gui/mixins/template_mixin.py
@@ -153,8 +153,8 @@ class TemplateMixin:
                 from config import GridConfig, SnapMode
                 grid_data = label_config['grid']
                 grid_config = GridConfig(
-                    size_x_mm=grid_data.get('size_x_mm', 2.0),
-                    size_y_mm=grid_data.get('size_y_mm', 2.0),
+                    size_x_mm=grid_data.get('size_x_mm', 1.0),
+                    size_y_mm=grid_data.get('size_y_mm', 1.0),
                     offset_x_mm=grid_data.get('offset_x_mm', 0.0),
                     offset_y_mm=grid_data.get('offset_y_mm', 0.0),
                     visible=grid_data.get('visible', True),

--- a/tests/run_all_persistence_tests.py
+++ b/tests/run_all_persistence_tests.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent.parent
+PYTHON = sys.executable
+
+TESTS = [
+    ("STEP 1: Default Grid 1mm", 'tests/test_step1_default_grid.py'),
+    ("STEP 2: Settings Manager", 'tests/test_step2_settings_manager.py'),
+    ("STEP 3: Grid Dialog Persistence", 'tests/test_step3_grid_dialog_persistence.py'),
+    ("STEP 4: Toolbar Persistence", 'tests/test_step4_toolbar_persistence.py'),
+    ("STEP 5: Canvas Grid Persistence", 'tests/test_step5_canvas_grid_persistence.py'),
+    ("STEP 6: Full Persistence Cycle", 'tests/test_step6_full_persistence_cycle.py'),
+]
+
+
+def main():
+    env = os.environ.copy()
+    env.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+    results = []
+
+    for stage_name, test_path in TESTS:
+        print("\n" + "=" * 60)
+        print(stage_name)
+        print("=" * 60)
+
+        process = subprocess.run(
+            [PYTHON, test_path],
+            cwd=BASE_DIR,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        print(process.stdout)
+        if process.stderr:
+            print(process.stderr)
+
+        results.append((stage_name, process.returncode))
+
+    print("\n" + "=" * 60)
+    print("FINAL RESULTS")
+    print("=" * 60)
+
+    all_passed = True
+    for stage_name, code in results:
+        status = "[OK]" if code == 0 else "[FAIL]"
+        print(f"{status} {stage_name} - EXIT CODE: {code}")
+        all_passed &= code == 0
+
+    print("\n" + "=" * 60)
+    if all_passed:
+        print("[SUCCESS] ALL PERSISTENCE TESTS PASSED!")
+    else:
+        print("[FAILURE] Some tests failed")
+
+    return 0 if all_passed else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_step1_default_grid.py
+++ b/tests/test_step1_default_grid.py
@@ -1,0 +1,51 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError as exc:  # pragma: no cover
+    print(f"[SKIP] PySide6 unavailable: {exc}")
+    sys.exit(0)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gui.main_window import MainWindow
+from utils.settings_manager import settings_manager
+
+
+def test_default_grid_size():
+    settings_manager.clear_all_settings()
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MainWindow()
+    app.processEvents()
+
+    canvas = window.canvas
+    print("=" * 60)
+    print("[STEP 1] DEFAULT GRID SIZE TEST")
+    print("=" * 60)
+    print(f"Grid Size X: {canvas.grid_config.size_x_mm}mm")
+    print(f"Grid Size Y: {canvas.grid_config.size_y_mm}mm")
+
+    ok = canvas.grid_config.size_x_mm == 1.0 and canvas.grid_config.size_y_mm == 1.0
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+    if ok:
+        print("\n[OK] Default grid size is 1mm x 1mm")
+        return 0
+
+    print(
+        "\n[FAIL] Expected 1.0mm x 1.0mm, "
+        f"got {canvas.grid_config.size_x_mm}mm x {canvas.grid_config.size_y_mm}mm"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(test_default_grid_size())

--- a/tests/test_step2_settings_manager.py
+++ b/tests/test_step2_settings_manager.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.settings_manager import settings_manager
+
+def test_settings_manager():
+    print("=" * 60)
+    print("[STEP 2] SETTINGS MANAGER TEST")
+    print("=" * 60)
+
+    settings_manager.clear_all_settings()
+    print("[1] Cleared all settings")
+
+    test_grid = {
+        'size_x': 1.5,
+        'size_y': 1.5,
+        'offset_x': 0.5,
+        'offset_y': 0.5,
+        'show_gridlines': False,
+        'snap_mode': 'objects',
+    }
+    settings_manager.save_grid_settings(test_grid)
+    print(f"[2] Saved grid settings: {test_grid}")
+
+    loaded_grid = settings_manager.load_grid_settings()
+    print(f"[3] Loaded grid settings: {loaded_grid}")
+
+    grid_ok = (
+        abs(loaded_grid['size_x'] - 1.5) < 1e-6 and
+        abs(loaded_grid['size_y'] - 1.5) < 1e-6 and
+        abs(loaded_grid['offset_x'] - 0.5) < 1e-6 and
+        abs(loaded_grid['offset_y'] - 0.5) < 1e-6 and
+        loaded_grid['show_gridlines'] is False and
+        loaded_grid['snap_mode'].value == 'objects'
+    )
+
+    test_toolbar = {
+        'show_grid': False,
+        'snap_to_grid': True,
+        'smart_guides': True,
+        'label_width': 50.0,
+        'label_height': 30.0,
+        'unit': 'inch',
+    }
+    settings_manager.save_toolbar_settings(test_toolbar)
+    print(f"[4] Saved toolbar settings: {test_toolbar}")
+
+    loaded_toolbar = settings_manager.load_toolbar_settings()
+    print(f"[5] Loaded toolbar settings: {loaded_toolbar}")
+
+    toolbar_ok = (
+        loaded_toolbar['show_grid'] is False and
+        loaded_toolbar['snap_to_grid'] is True and
+        loaded_toolbar['smart_guides'] is True and
+        abs(loaded_toolbar['label_width'] - 50.0) < 1e-6 and
+        abs(loaded_toolbar['label_height'] - 30.0) < 1e-6 and
+        loaded_toolbar['unit'] == 'inch'
+    )
+
+    print("\n" + "=" * 60)
+    if grid_ok and toolbar_ok:
+        print("[OK] SettingsManager save/load works correctly")
+        return 0
+
+    print("[FAIL] SettingsManager failed")
+    if not grid_ok:
+        print("  - Grid settings mismatch")
+    if not toolbar_ok:
+        print("  - Toolbar settings mismatch")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(test_settings_manager())

--- a/tests/test_step3_grid_dialog_persistence.py
+++ b/tests/test_step3_grid_dialog_persistence.py
@@ -1,0 +1,79 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError as exc:  # pragma: no cover
+    print(f"[SKIP] PySide6 unavailable: {exc}")
+    sys.exit(0)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gui.grid_settings_dialog import GridSettingsDialog
+from gui.main_window import MainWindow
+from utils.settings_manager import settings_manager
+
+
+def test_grid_dialog_persistence():
+    print("=" * 60)
+    print("[STEP 3] GRID DIALOG PERSISTENCE TEST")
+    print("=" * 60)
+
+    settings_manager.clear_all_settings()
+
+    preset = {
+        'size_x': 1.5,
+        'size_y': 2.0,
+        'offset_x': 0.5,
+        'offset_y': 1.0,
+        'show_gridlines': False,
+        'snap_mode': 'objects',
+    }
+    settings_manager.save_grid_settings(preset)
+    print(f"[1] Pre-saved test settings: {preset}")
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MainWindow()
+    app.processEvents()
+
+    dialog = GridSettingsDialog(window.canvas.grid_config, parent=window)
+    app.processEvents()
+
+    loaded_x = dialog.size_x_spin.value()
+    loaded_y = dialog.size_y_spin.value()
+    loaded_offset_x = dialog.offset_x_spin.value()
+    loaded_offset_y = dialog.offset_y_spin.value()
+    print(f"[2] Dialog loaded: size_x={loaded_x}, size_y={loaded_y}")
+
+    dialog.size_x_spin.setValue(3.0)
+    dialog.size_y_spin.setValue(3.0)
+    dialog.accept()
+
+    saved = settings_manager.load_grid_settings()
+    print(f"[3] After accept, saved settings: {saved}")
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+    success = (
+        abs(loaded_x - 1.5) < 1e-6 and
+        abs(loaded_y - 2.0) < 1e-6 and
+        abs(saved['size_x'] - 3.0) < 1e-6 and
+        abs(saved['size_y'] - 3.0) < 1e-6
+    )
+
+    print("\n" + "=" * 60)
+    if success:
+        print("[OK] Grid Dialog persistence works")
+        return 0
+
+    print("[FAIL] Grid Dialog persistence failed")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(test_grid_dialog_persistence())

--- a/tests/test_step4_toolbar_persistence.py
+++ b/tests/test_step4_toolbar_persistence.py
@@ -1,0 +1,79 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError as exc:  # pragma: no cover
+    print(f"[SKIP] PySide6 unavailable: {exc}")
+    sys.exit(0)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gui.main_window import MainWindow
+from utils.settings_manager import settings_manager
+
+
+def test_toolbar_persistence():
+    print("=" * 60)
+    print("[STEP 4] TOOLBAR PERSISTENCE TEST")
+    print("=" * 60)
+
+    settings_manager.clear_all_settings()
+
+    preset = {
+        'show_grid': False,
+        'snap_to_grid': True,
+        'smart_guides': True,
+        'label_width': 50.0,
+        'label_height': 30.0,
+        'unit': 'mm',
+    }
+    settings_manager.save_toolbar_settings(preset)
+    print(f"[1] Pre-saved toolbar settings: {preset}")
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.processEvents()
+
+    show_grid_state = window.grid_checkbox.isChecked()
+    snap_state = window.snap_checkbox.isChecked()
+    smart_guides_state = window.guides_checkbox.isChecked()
+    label_width = window.canvas.width_mm
+    label_height = window.canvas.height_mm
+
+    print(f"[2] Loaded states:\n    Show Grid: {show_grid_state}\n    Snap to Grid: {snap_state}\n    Smart Guides: {smart_guides_state}\n    Label Size: {label_width}x{label_height}mm")
+
+    window.grid_checkbox.setChecked(True)
+    app.processEvents()
+
+    saved = settings_manager.load_toolbar_settings()
+    print(f"[3] After toggle, saved settings: {saved}")
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+    success = (
+        show_grid_state is False and
+        snap_state is True and
+        smart_guides_state is True and
+        abs(label_width - 50.0) < 1e-6 and
+        abs(label_height - 30.0) < 1e-6 and
+        saved['show_grid'] is True
+    )
+
+    print("\n" + "=" * 60)
+    if success:
+        print("[OK] Toolbar persistence works")
+        return 0
+
+    print("[FAIL] Toolbar persistence failed")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(test_toolbar_persistence())

--- a/tests/test_step5_canvas_grid_persistence.py
+++ b/tests/test_step5_canvas_grid_persistence.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError as exc:  # pragma: no cover
+    print(f"[SKIP] PySide6 unavailable: {exc}")
+    sys.exit(0)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gui.main_window import MainWindow
+from utils.settings_manager import settings_manager
+
+
+def test_canvas_grid_persistence():
+    print("=" * 60)
+    print("[STEP 5] CANVAS GRID PERSISTENCE TEST")
+    print("=" * 60)
+
+    settings_manager.clear_all_settings()
+
+    preset = {
+        'size_x': 1.5,
+        'size_y': 2.5,
+        'offset_x': 0.5,
+        'offset_y': 1.5,
+        'show_gridlines': True,
+        'snap_mode': 'grid',
+    }
+    settings_manager.save_grid_settings(preset)
+    print(f"[1] Pre-saved grid settings: {preset}")
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.processEvents()
+
+    canvas = window.canvas
+    print(f"[2] Canvas grid state:\n    Size X: {canvas.grid_config.size_x_mm}mm\n    Size Y: {canvas.grid_config.size_y_mm}mm\n    Offset X: {canvas.grid_config.offset_x_mm}mm\n    Offset Y: {canvas.grid_config.offset_y_mm}mm")
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+    success = (
+        abs(canvas.grid_config.size_x_mm - 1.5) < 1e-6 and
+        abs(canvas.grid_config.size_y_mm - 2.5) < 1e-6 and
+        abs(canvas.grid_config.offset_x_mm - 0.5) < 1e-6 and
+        abs(canvas.grid_config.offset_y_mm - 1.5) < 1e-6
+    )
+
+    print("\n" + "=" * 60)
+    if success:
+        print("[OK] Canvas applies saved grid settings on startup")
+        return 0
+
+    print("[FAIL] Canvas did not apply saved grid settings")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(test_canvas_grid_persistence())

--- a/tests/test_step6_full_persistence_cycle.py
+++ b/tests/test_step6_full_persistence_cycle.py
@@ -1,0 +1,101 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError as exc:  # pragma: no cover
+    print(f"[SKIP] PySide6 unavailable: {exc}")
+    sys.exit(0)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gui.grid_settings_dialog import GridSettingsDialog
+from gui.main_window import MainWindow
+from utils.settings_manager import settings_manager
+
+
+def test_full_persistence_cycle():
+    print("=" * 60)
+    print("[STEP 6] FULL PERSISTENCE CYCLE TEST")
+    print("=" * 60)
+
+    app = QApplication.instance() or QApplication(sys.argv)
+
+    settings_manager.clear_all_settings()
+    print("[1] Cleared all settings")
+
+    print("\n[2] FIRST LAUNCH")
+    window1 = MainWindow()
+    window1.show()
+    app.processEvents()
+
+    default_grid_x = window1.canvas.grid_config.size_x_mm
+    default_show_grid = window1.grid_checkbox.isChecked()
+    print(f"    Default grid size: {default_grid_x}mm")
+    print(f"    Default show grid: {default_show_grid}")
+
+    dialog = GridSettingsDialog(window1.canvas.grid_config, parent=window1)
+    dialog.size_x_spin.setValue(1.25)
+    dialog.size_y_spin.setValue(1.75)
+    dialog.accept()
+    print("[3] Changed grid via dialog: 1.25mm x 1.75mm")
+
+    window1.grid_checkbox.setChecked(False)
+    window1.snap_checkbox.setChecked(True)
+    app.processEvents()
+    print("[4] Changed toolbar: show_grid=False, snap=True")
+
+    window1.close()
+    window1.deleteLater()
+    app.processEvents()
+    print("[5] Closed first instance")
+
+    print("\n[6] SECOND LAUNCH")
+    window2 = MainWindow()
+    window2.show()
+    app.processEvents()
+
+    loaded_grid_x = window2.canvas.grid_config.size_x_mm
+    loaded_grid_y = window2.canvas.grid_config.size_y_mm
+    loaded_show_grid = window2.grid_checkbox.isChecked()
+    loaded_snap = window2.snap_checkbox.isChecked()
+
+    print("[7] Second launch state:")
+    print(f"    Grid size: {loaded_grid_x}mm x {loaded_grid_y}mm")
+    print(f"    Show Grid: {loaded_show_grid}")
+    print(f"    Snap to Grid: {loaded_snap}")
+
+    window2.close()
+    window2.deleteLater()
+    app.processEvents()
+
+    success = (
+        abs(loaded_grid_x - 1.25) < 1e-6 and
+        abs(loaded_grid_y - 1.75) < 1e-6 and
+        loaded_show_grid is False and
+        loaded_snap is True
+    )
+
+    print("\n" + "=" * 60)
+    if success:
+        print("[OK] Full persistence cycle works!")
+        print("     All settings preserved between sessions")
+        return 0
+
+    print("[FAIL] Settings were not preserved")
+    if abs(loaded_grid_x - 1.25) >= 1e-6:
+        print(f"  - Grid X: expected 1.25, got {loaded_grid_x}")
+    if abs(loaded_grid_y - 1.75) >= 1e-6:
+        print(f"  - Grid Y: expected 1.75, got {loaded_grid_y}")
+    if loaded_show_grid is not False:
+        print(f"  - Show Grid: expected False, got {loaded_show_grid}")
+    if loaded_snap is not True:
+        print(f"  - Snap: expected True, got {loaded_snap}")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(test_full_persistence_cycle())

--- a/utils/settings_manager.py
+++ b/utils/settings_manager.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Settings Manager для збереження користувацьких налаштувань"""
+
+from PySide6.QtCore import QSettings
+
+from utils.logger import logger
+from config import SnapMode
+
+
+class SettingsManager:
+    """Управління налаштуваннями застосунку через QSettings."""
+
+    def __init__(self):
+        # Windows: HKEY_CURRENT_USER\Software\Anthropic\ZPL_Designer
+        # Linux: ~/.config/Anthropic/ZPL_Designer.conf
+        # macOS: ~/Library/Preferences/com.Anthropic.ZPL_Designer.plist
+        self.settings = QSettings("Anthropic", "ZPL_Designer")
+        logger.debug("[SETTINGS] SettingsManager initialized")
+
+    # ========== GRID SETTINGS ==========
+
+    def save_grid_settings(self, settings_dict):
+        """Зберегти налаштування сітки."""
+        self.settings.setValue("grid/size_x", settings_dict.get("size_x", 1.0))
+        self.settings.setValue("grid/size_y", settings_dict.get("size_y", 1.0))
+        self.settings.setValue("grid/offset_x", settings_dict.get("offset_x", 0.0))
+        self.settings.setValue("grid/offset_y", settings_dict.get("offset_y", 0.0))
+        self.settings.setValue("grid/show_gridlines", settings_dict.get("show_gridlines", True))
+        snap_mode_value = settings_dict.get("snap_mode", SnapMode.GRID)
+        if isinstance(snap_mode_value, SnapMode):
+            snap_mode_to_store = snap_mode_value.value
+        else:
+            snap_mode_to_store = str(snap_mode_value)
+
+        self.settings.setValue("grid/snap_mode", snap_mode_to_store)
+
+        self.settings.sync()
+        logger.debug(f"[SETTINGS] Grid settings saved: {settings_dict}")
+
+    def load_grid_settings(self):
+        """Завантажити налаштування сітки."""
+        settings = {
+            "size_x": self.settings.value("grid/size_x", defaultValue=1.0, type=float),
+            "size_y": self.settings.value("grid/size_y", defaultValue=1.0, type=float),
+            "offset_x": self.settings.value("grid/offset_x", defaultValue=0.0, type=float),
+            "offset_y": self.settings.value("grid/offset_y", defaultValue=0.0, type=float),
+            "show_gridlines": self.settings.value("grid/show_gridlines", defaultValue=True, type=bool),
+            "snap_mode": self._load_snap_mode(),
+        }
+
+        logger.debug(f"[SETTINGS] Grid settings loaded: {settings}")
+        return settings
+
+    # ========== TOOLBAR SETTINGS ==========
+
+    def save_toolbar_settings(self, settings_dict):
+        """Зберегти налаштування toolbar."""
+        self.settings.setValue("toolbar/show_grid", settings_dict.get("show_grid", True))
+        self.settings.setValue("toolbar/snap_to_grid", settings_dict.get("snap_to_grid", True))
+        self.settings.setValue("toolbar/smart_guides", settings_dict.get("smart_guides", True))
+        self.settings.setValue("toolbar/label_width", settings_dict.get("label_width", 28.0))
+        self.settings.setValue("toolbar/label_height", settings_dict.get("label_height", 28.0))
+        self.settings.setValue("toolbar/unit", settings_dict.get("unit", "mm"))
+
+        self.settings.sync()
+        logger.debug(f"[SETTINGS] Toolbar settings saved: {settings_dict}")
+
+    def load_toolbar_settings(self):
+        """Завантажити налаштування toolbar."""
+        settings = {
+            "show_grid": self.settings.value("toolbar/show_grid", defaultValue=True, type=bool),
+            "snap_to_grid": self.settings.value("toolbar/snap_to_grid", defaultValue=True, type=bool),
+            "smart_guides": self.settings.value("toolbar/smart_guides", defaultValue=True, type=bool),
+            "label_width": self.settings.value("toolbar/label_width", defaultValue=28.0, type=float),
+            "label_height": self.settings.value("toolbar/label_height", defaultValue=28.0, type=float),
+            "unit": self.settings.value("toolbar/unit", defaultValue="mm", type=str),
+        }
+
+        logger.debug(f"[SETTINGS] Toolbar settings loaded: {settings}")
+        return settings
+
+    def clear_all_settings(self):
+        """Очистити всі налаштування (для тестів)."""
+        self.settings.clear()
+        self.settings.sync()
+        logger.debug("[SETTINGS] All settings cleared")
+
+    def _load_snap_mode(self):
+        """Допоміжний метод для завантаження SnapMode."""
+        snap_mode_value = self.settings.value(
+            "grid/snap_mode",
+            defaultValue=SnapMode.GRID.value,
+            type=str,
+        )
+
+        try:
+            snap_mode = SnapMode(snap_mode_value)
+        except ValueError:
+            logger.warning(
+                f"[SETTINGS] Unknown snap mode '{snap_mode_value}', fallback to {SnapMode.GRID.value}"
+            )
+            snap_mode = SnapMode.GRID
+
+        return snap_mode
+
+
+settings_manager = SettingsManager()


### PR DESCRIPTION
## Summary
- add a centralized settings manager around QSettings and switch default grid spacing to 1 mm
- load and persist grid, toolbar, and label configuration from saved settings across the canvas, dialog, and main window
- refresh element defaults, template fallbacks, and add integration tests and runner scripts that verify the persistence workflow

## Testing
- python tests/run_all_persistence_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e28817926c8320b194ea3e7fd8d33c